### PR TITLE
Skip over comments

### DIFF
--- a/src/js_lexer/src/lib.rs
+++ b/src/js_lexer/src/lib.rs
@@ -138,6 +138,30 @@ impl<'a> Lexer<'a> {
                 if self.character == Some('=') {
                     self.step();
                     self.token = Token::SlashEquals;
+                } else if self.character == Some('/') {
+                    'single_line_comment: loop {
+                        self.step();
+                        if self.character == Some('\n') || self.character == Some('\r') {
+                            break 'single_line_comment;
+                        } else if self.character == None {
+                            break 'single_line_comment;
+                        }
+                    }
+                    self.next_token();
+                } else if self.character == Some('*') {
+                    'multi_line_comment: loop {
+                        self.step();
+                        if self.character == Some('*') {
+                            self.step();
+                            if self.character == Some('/') {
+                                self.step();
+                                break 'multi_line_comment;
+                            }
+                        } else if self.character == None {
+                            break 'multi_line_comment;
+                        }
+                    }
+                    self.next_token();
                 } else {
                     self.token = Token::Slash;
                 }

--- a/src/js_lexer/tests/lexer_test.rs
+++ b/src/js_lexer/tests/lexer_test.rs
@@ -196,3 +196,30 @@ fn test_numeric_literals() {
     expect_number("1", "1");
     expect_number("120", "120");
 }
+
+#[test]
+fn test_comments() {
+    let input = "// comment 1
+    let a;
+    /* comment 2 */
+    let b;
+    ";
+
+    let tokens = vec![
+        Token::Let,
+        Token::Identifier,
+        Token::Semicolon,
+        Token::Let,
+        Token::Identifier,
+        Token::Semicolon,
+    ];
+
+    let logger = LoggerImpl::new();
+    let mut lexer = Lexer::new(input, &logger);
+    for (idx, token) in tokens.iter().enumerate() {
+        if idx != 0 {
+            lexer.next_token();
+        }
+        assert_eq!(token, &lexer.token);
+    }
+}


### PR DESCRIPTION
The lexer will now treat both single and multi line comments as whitespace and skip over them.